### PR TITLE
Problems with incomplete list after filter removal.

### DIFF
--- a/src/components/Navigator/ListItem.js
+++ b/src/components/Navigator/ListItem.js
@@ -124,7 +124,7 @@ class ListItem extends React.Component {
       const category = this.props.post.node.frontmatter.category;
       const categoryFilter = this.props.categoryFilter;
 
-      if (categoryFilter === "all posts" && this.state.hidden) {
+      if (categoryFilter === "all posts") {
         this.setState({ hidden: false });
       } else if (category !== categoryFilter) {
         this.setState({ hidden: true });


### PR DESCRIPTION
In line 127 of this file, I think the `&& this.state.hidden` condition is not required and can cause some problems.

The condition causes some posts to not appear on the list when you reselect "all posts" button ( after removing the filter ).

#### The following is an example of this problem

When I click on the "Life" category, only "Life" posts are displayed, and then click the "all posts" button again, all "Life" posts disappear.

|![](https://i.imgur.com/T02GbOb.png)|![](https://i.imgur.com/KzUFTjM.png)|
|---|---|
|![](https://i.imgur.com/loc9Vu9.png)|<== all Life posts disappear|

----

My demo didn't change any code. And it worked fine when I delete `&& this.state.hidden`.

PS: Your demo site also has this problem, you can check it out.