### PR TITLE
Fix a filter display logic problem

### DIFF
--- a/src/components/Navigator/ListHeader.js
+++ b/src/components/Navigator/ListHeader.js
@@ -9,6 +9,17 @@ import ExpandLessIcon from "material-ui-icons/ExpandLess";
 const styles = theme => ({
   closed: {
     display: "none",
+    zIndex: 99,
+    background: theme.base.colors.background,
+    "&::after": {
+      content: `""`,
+      position: "absolute",
+      top: 0,
+      left: theme.base.sizes.linesMargin,
+      right: theme.base.sizes.linesMargin,
+      height: 0,
+      borderTop: `1px solid ${theme.base.colors.lines}`
+    },
     ".is-aside.closed &, .moving-featured.closed &": {
       display: "flex",
       flexDirection: "row",
@@ -95,8 +106,7 @@ const ListHeader = props => {
           </IconButton>
         </div>
       )}
-      {navigatorShape === "open" &&
-        categoryFilter !== "all posts" && (
+      {categoryFilter !== "all posts" && (
           <div className={classes.filter}>
             <small>Active category filter:</small> <strong>{categoryFilter}</strong>
             <IconButton


### PR DESCRIPTION
#### How to reproduce the bug

1. Open demo, click "About" page (or other pages).
2. Set a filter and return to the post list (home page).
3. The filter disappears, but is actually enabled.

All pages have this problem. This bug occurs when "LIST OF POSTS" is closed (`navigatorShape === "closed"`) and returns to the home page.

#### Reason

In [ListHeader.js#L98](https://github.com/greglobinski/gatsby-starter-personal-blog/blob/master/src/components/Navigator/ListHeader.js#L98) this line, `navigatorShape === "open"` is not required. Because the filter should remain on the page when the list is collapsed.

The `navigatorShape === "open"` condition causes the filter to be hidden.

You can check out your demo site.

#### Changed what

Remove a judgment condition, mask the filter with zIndex, and redraw the borderTop line.