### PR TITLE
Fix Issue: Blog post dates rendering as yesterday

### DIFF
--- a/src/components/Post/PostHeader.js
+++ b/src/components/Post/PostHeader.js
@@ -44,8 +44,11 @@ const PostHeader = props => {
   const { classes, title, subTitle, date } = props;
 
   function myDate(dateString) {
-    const dateObj = new Date(dateString);
-    const dateToShow = dateObj.toDateString();
+    const dateObj = new Date(dateString).toUTCString();
+    const dateToShow = dateObj
+      .split(" ")
+      .slice(0, 4)
+      .join(" ");
 
     return dateToShow;
   }


### PR DESCRIPTION
**Issue Example:**
 [Date on blog post from demo repo](https://prnt.sc/k0urwy)
[Date as renders on demo site](https://prnt.sc/k0us4f)

**Cause:** [Stack Overflow](https://goo.gl/tNqH7H)

**Proposed Solution:** convert dateString .toUTCString(), parse off time.