### PR TITLE
fix: pathPrefix property location

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,7 +33,6 @@ module.exports = {
     title: config.siteTitle,
     description: config.siteDescription,
     siteUrl: config.siteUrl,
-    pathPrefix: config.pathPrefix,
     algolia: {
       appId: process.env.ALGOLIA_APP_ID ? process.env.ALGOLIA_APP_ID : "",
       searchOnlyApiKey: process.env.ALGOLIA_SEARCH_ONLY_API_KEY
@@ -45,6 +44,7 @@ module.exports = {
       appId: process.env.FB_APP_ID ? process.env.FB_APP_ID : ""
     }
   },
+  pathPrefix: config.pathPrefix,
   plugins: [
     `gatsby-plugin-react-next`,
     {


### PR DESCRIPTION
The pathPrefix property is located in the wrong position. It does not work in the prev location.