### PR TITLE
Add an empty default to postSlug

### DIFF
--- a/src/components/Seo/Seo.js
+++ b/src/components/Seo/Seo.js
@@ -8,7 +8,7 @@ const Seo = props => {
   const postTitle = ((data || {}).frontmatter || {}).title;
   const postDescription = ((data || {}).frontmatter || {}).description;
   const postCover = ((data || {}).frontmatter || {}).cover;
-  const postSlug = ((data || {}).fields || {}).slug;
+  const postSlug = ((data || {}).fields || {}).slugi || '';
 
   const title = postTitle ? `${postTitle} - ${config.shortSiteTitle}` : config.siteTitle;
   const description = postDescription ? postDescription : config.siteDescription;


### PR DESCRIPTION
Hey Greg,

I noticed that the og:url header tag had "undefined" appended onto the base url for any page that wasn't a post. This is a naive solution to the problem. Not sure if it's the ideal one.

Will