### PR TITLE
Fixes #51: Page slug is prefixed in wide view but not in mobile view

### DIFF
--- a/src/components/InfoBar/TopMenu.js
+++ b/src/components/InfoBar/TopMenu.js
@@ -1,15 +1,16 @@
-import { Manager, Target, Popper } from "react-popper";
-import classNames from "classnames";
-import ClickAwayListener from "@material-ui/core/ClickAwayListener";
-import Grow from "@material-ui/core/Grow";
-import IconButton from "@material-ui/core/IconButton";
-import injectSheet from "react-jss";
-import MenuItem from "@material-ui/core/MenuItem";
-import MenuList from "@material-ui/core/MenuList";
-import MoreVertIcon from "@material-ui/icons/MoreVert";
-import Paper from "@material-ui/core/Paper";
-import PropTypes from "prop-types";
-import React from "react";
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+import Grow from '@material-ui/core/Grow';
+import IconButton from '@material-ui/core/IconButton';
+import MenuItem from '@material-ui/core/MenuItem';
+import MenuList from '@material-ui/core/MenuList';
+import Paper from '@material-ui/core/Paper';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+import classNames from 'classnames';
+import Link from 'gatsby-link';
+import PropTypes from 'prop-types';
+import React from 'react';
+import injectSheet from 'react-jss';
+import {Manager, Popper, Target} from 'react-popper';
 
 const styles = theme => ({
   topMenu: {
@@ -88,7 +89,7 @@ class TopMenu extends React.Component {
                       const { fields, frontmatter } = page.node;
 
                       return (
-                        <a key={fields.slug} href={fields.slug} style={{ display: "block" }}>
+                        <Link key={fields.slug} to={fields.slug} style={{ display: "block" }}>
                           <MenuItem
                             onClick={e => {
                               this.props.pageLinkOnClick(e);
@@ -97,10 +98,10 @@ class TopMenu extends React.Component {
                           >
                             {frontmatter.menuTitle ? frontmatter.menuTitle : frontmatter.title}
                           </MenuItem>
-                        </a>
+                        </Link>
                       );
                     })}
-                    <a href="/contact/" style={{ display: "block" }}>
+                    <Link to="/contact/" style={{ display: "block" }}>
                       <MenuItem
                         onClick={e => {
                           this.props.pageLinkOnClick(e);
@@ -109,7 +110,7 @@ class TopMenu extends React.Component {
                       >
                         Contact
                       </MenuItem>
-                    </a>
+                    </Link>
                   </MenuList>
                 </Paper>
               </Grow>


### PR DESCRIPTION
This PR fixes #51 by making use of `gatsby-link` instead of anchor dom element.