### PR TITLE
Prevent build errors on Posts missing a `cover` image

### DIFF
--- a/src/components/Navigator/ListItem.js
+++ b/src/components/Navigator/ListItem.js
@@ -149,19 +149,22 @@ class ListItem extends React.Component {
           to={post.node.fields.slug}
           onClick={linkOnClick}
         >
-          <div className={`${classes.listItemPointer} pointer`}>
-            <LazyLoad height={60} overflow={true} throttle={300} once={true} offset={100}>
-              <picture>
-                <source
-                  type="image/webp"
-                  srcSet={post.node.frontmatter.cover.children[0].resolutions.srcSetWebp}
-                />
-                <source srcSet={post.node.frontmatter.cover.children[0].resolutions.srcSet} />
-                <img src={post.node.frontmatter.cover.children[0].resolutions.src} alt="" />
-              </picture>
-            </LazyLoad>
-            {/*<Img sizes={post.node.frontmatter.cover.children[0].sizes} />*/}
-          </div>
+          {post.node.frontmatter.cover &&
+            post.node.frontmatter.cover.children[0] && (
+              <div className={`${classes.listItemPointer} pointer`}>
+                <LazyLoad height={60} overflow={true} throttle={300} once={true} offset={100}>
+                  <picture>
+                    <source
+                      type="image/webp"
+                      srcSet={post.node.frontmatter.cover.children[0].resolutions.srcSetWebp}
+                    />
+                    <source srcSet={post.node.frontmatter.cover.children[0].resolutions.srcSet} />
+                    <img src={post.node.frontmatter.cover.children[0].resolutions.src} alt="" />
+                  </picture>
+                </LazyLoad>
+              </div>
+            )}
+          
           <div className={classes.listItemText}>
             <h1>{post.node.frontmatter.title}</h1>
             {post.node.frontmatter.subTitle && <h2>{post.node.frontmatter.subTitle}</h2>}


### PR DESCRIPTION
Hi @greglobinski - Amazing work here!

I made a change to prevent compile errors while writing new posts. 

My use case: I don't want to pick my cover image first. 