### PR TITLE
Should send plain text to algolia for searching rather than send full markdown content

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,5 @@
 require("dotenv").config();
+const removeMarkdown = require("remove-markdown");
 const config = require("./content/meta/config");
 
 const query = `{
@@ -24,7 +25,13 @@ const query = `{
 const queries = [
   {
     query,
-    transformer: ({ data }) => data.allMarkdownRemark.edges.map(({ node }) => node)
+    transformer: ({ data }) =>
+      data.allMarkdownRemark.edges.map(({ node }) => {
+        if (node.internal && node.internal.content) {
+          node.internal.content = removeMarkdown(node.internal.content).substring(1, 1000);
+        }
+        return node;
+      })
   }
 ];
 

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "rebound": "^0.1.0",
     "redux": "^4.0.0",
     "redux-devtools-extension": "^2.13.5",
+    "remove-markdown": "^0.3.0",
     "screenfull": "^3.3.2"
   }
 }


### PR DESCRIPTION
I found no benefit to send fully content of markdown file as well as it can make the search engine confused about the content which the user wants to look up.

Also, many people experienced the issue with heavy data sending to Algolia, we should limit the number of characters to be sent (Read more at https://discourse.algolia.com/t/contact-us-if-you-need-an-extended-quota/2993)